### PR TITLE
HCS-1611: Set VNet name, id, and RG on cluster read

### DIFF
--- a/examples/cluster_vnet_peering/_config.tf
+++ b/examples/cluster_vnet_peering/_config.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    hcs = {
+      // TODO: Update this to hashicorp/hcs when the provider is available on the registry
+      source  = "unreleased.hashicorp.com/hashicorp/hcs"
+      version = "0.0.1"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.39.0"
+    }
+  }
+}
+
+provider "hcs" {}
+
+provider "azurerm" {
+  features {}
+}

--- a/examples/cluster_vnet_peering/main.tf
+++ b/examples/cluster_vnet_peering/main.tf
@@ -1,0 +1,32 @@
+resource "azurerm_resource_group" "example" {
+  name     = "hcs-tf-example"
+  location = "westus2"
+}
+
+resource "hcs_cluster" "example" {
+  resource_group_name      = azurerm_resource_group.example.name
+  managed_application_name = "hcs-tf-example"
+  email                    = "me@example.com"
+  cluster_mode             = "production"
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "peternetwork"
+  resource_group_name = azurerm_resource_group.example.name
+  address_space       = ["10.0.2.0/24"]
+  location            = "westus2"
+}
+
+resource "azurerm_virtual_network_peering" "cluster-to-network" {
+  name                      = "peertonetwork"
+  resource_group_name       = hcs_cluster.example.vnet_resource_group_name
+  virtual_network_name      = hcs_cluster.example.vnet_name
+  remote_virtual_network_id = azurerm_virtual_network.example.id
+}
+
+resource "azurerm_virtual_network_peering" "network-to-cluster" {
+  name                      = "peertocluster"
+  resource_group_name       = azurerm_resource_group.example.name
+  virtual_network_name      = azurerm_virtual_network.example.name
+  remote_virtual_network_id = hcs_cluster.example.vnet_id
+}

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-07-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/managedapplications"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources"
 	"github.com/Azure/go-autorest/autorest"
@@ -55,6 +56,9 @@ type Client struct {
 
 	// ManagedClusters is the client used for Azure Container services managed clusters CRUD.
 	ManagedClusters *containerservice.ManagedClustersClient
+
+	// VNet is the client used for Azure Virtual Networks CRUD
+	VNet *network.VirtualNetworksClient
 
 	// Config is the provider config which contains HCS specific configuration values.
 	Config Config
@@ -115,6 +119,10 @@ func Build(ctx context.Context, options Options) (*Client, error) {
 	managedClustersClient := containerservice.NewManagedClustersClient(options.AzureAuthConfig.SubscriptionID)
 	configureAutoRestClient(&managedClustersClient.Client, auth, options.ProviderUserAgent)
 	client.ManagedClusters = &managedClustersClient
+
+	vNetClient := network.NewVirtualNetworksClient(options.AzureAuthConfig.SubscriptionID)
+	configureAutoRestClient(&vNetClient.Client, auth, options.ProviderUserAgent)
+	client.VNet = &vNetClient
 
 	return &client, nil
 }

--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/managedapplications"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -146,6 +147,21 @@ func resourceCluster() *schema.Resource {
 				Computed: true,
 			},
 			// Computed outputs
+			"vnet_id": {
+				Description: "The ID of the cluster's managed VNet.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"vnet_name": {
+				Description: "The name of the cluster's managed VNet.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"vnet_resource_group_name": {
+				Description: "The resource group that the cluster's managed VNet belongs to. This will be the same value as `managed_resource_group_name`.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 			"state": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -455,7 +471,26 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 		)
 	}
 
-	return setClusterData(d, managedApp, cluster)
+	// Fetch the managed VNet
+	managedResourceGroupName, err := helper.ParseResourceGroupNameFromID(*managedApp.ManagedResourceGroupID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// VNet name has a '-vnet' suffix that is not saved on the cluster properties
+	vNetName := strings.TrimSuffix(cluster.Properties.VnetName, "-vnet") + "-vnet"
+	vNet, err := meta.(*clients.Client).VNet.Get(ctx, managedResourceGroupName, vNetName, "")
+	if err != nil {
+		return diag.Errorf("error fetching VNet for HCS Cluster (Managed Application ID %q) (Managed Resource Group Name %q) (VNet Name %q) (Correlation ID %q): %+v",
+			managedAppID,
+			managedResourceGroupName,
+			vNetName,
+			meta.(*clients.Client).CorrelationRequestID,
+			err,
+		)
+	}
+
+	return setClusterData(d, managedApp, cluster, vNet)
 }
 
 func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -637,7 +672,7 @@ func validateClusterImportString(s string) (string, string, error) {
 // setClusterData sets the KV pairs of the cluster resource schema.
 // We do not set consul_root_token_accessor_id and consul_root_token_secret_id here since
 // the original root token is only available during cluster creation.
-func setClusterData(d *schema.ResourceData, managedApp managedapplications.Application, cluster models.HashicorpCloudConsulamaAmaClusterResponse) diag.Diagnostics {
+func setClusterData(d *schema.ResourceData, managedApp managedapplications.Application, cluster models.HashicorpCloudConsulamaAmaClusterResponse, vNet network.VirtualNetwork) diag.Diagnostics {
 	resourceGroupName, err := helper.ParseResourceGroupNameFromID(*managedApp.ID)
 	if err != nil {
 		return diag.FromErr(err)
@@ -679,6 +714,26 @@ func setClusterData(d *schema.ResourceData, managedApp managedapplications.Appli
 		return diag.FromErr(err)
 	}
 
+	err = d.Set("vnet_id", *vNet.ID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = d.Set("vnet_name", *vNet.Name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	managedResourceGroupName, err := helper.ParseResourceGroupNameFromID(*managedApp.ManagedResourceGroupID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = d.Set("vnet_resource_group_name", managedResourceGroupName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	err = d.Set("consul_version", cluster.Properties.ConsulCurrentVersion)
 	if err != nil {
 		return diag.FromErr(err)
@@ -709,10 +764,6 @@ func setClusterData(d *schema.ResourceData, managedApp managedapplications.Appli
 		return diag.FromErr(err)
 	}
 
-	managedResourceGroupName, err := helper.ParseResourceGroupNameFromID(*managedApp.ManagedResourceGroupID)
-	if err != nil {
-		return diag.FromErr(err)
-	}
 	err = d.Set("managed_resource_group_name", managedResourceGroupName)
 	if err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
[HCS-1611](https://hashicorp.atlassian.net/browse/HCS-1611) Set managed VNet attributes on cluster read. They are useful for peering other VNets. Thanks to @jipperinbham for calling these attributes out.
```
> tf show
# hcs_cluster.test:
resource "hcs_cluster" "test" {
   ...
    vnet_cidr                      = "172.25.16.0/24"
    vnet_id                        = "/subscriptions/XXX/resourceGroups/hcs-tf-vnet-rg-mrg-hcs-tf-vnet-test/providers/Microsoft.Network/virtualNetworks/11eb40d4-8918-cdf1-83ea-0242ac11000d-vnet"
    vnet_name                      = "11eb40d4-8918-cdf1-83ea-0242ac11000d-vnet"
    vnet_resource_group_name       = "hcs-tf-vnet-rg-mrg-hcs-tf-vnet-test"
}
```
