### PR TITLE
Add marketplace agreement example to docs index and README

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,15 @@ provider "azurerm" {
   features {}
 }
 
+// If you have not already done so, accept the HCS Marketplace agreement
+data "hcs_plan_defaults" "hcs_plan" {}
+
+resource "azurerm_marketplace_agreement" "hcs_marketplace_agreement" {
+  publisher = data.hcs_plan_defaults.hcs_plan.publisher
+  offer     = data.hcs_plan_defaults.hcs_plan.offer
+  plan      = data.hcs_plan_defaults.hcs_plan.plan_name
+}
+
 // Create an Azure Resource Group
 resource "azurerm_resource_group" "example" {
   name     = "hcs-tf-example-rg"

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -6,6 +6,15 @@ provider "azurerm" {
   features {}
 }
 
+// If you have not already done so, accept the HCS Marketplace agreement
+data "hcs_plan_defaults" "hcs_plan" {}
+
+resource "azurerm_marketplace_agreement" "hcs_marketplace_agreement" {
+  publisher = data.hcs_plan_defaults.hcs_plan.publisher
+  offer     = data.hcs_plan_defaults.hcs_plan.offer
+  plan      = data.hcs_plan_defaults.hcs_plan.plan_name
+}
+
 // Create an Azure Resource Group
 resource "azurerm_resource_group" "example" {
   name     = "hcs-tf-example-rg"


### PR DESCRIPTION
We want to let our users know that the Azure Marketplace agreement must be accepted before they can provision clusters with the HCS provider. Thanks @xargs-P for suggesting this in https://github.com/hashicorp/terraform-provider-hcs/pull/25#issuecomment-750597859