### PR TITLE
HCS-1627: min_consul_version property for setting initial version and upgrading

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ resource "hcs_cluster" "primary" {
   managed_application_name = "hcs-tf-federation-primary"
   email                    = "me@example.com"
   cluster_mode             = "production"
-  consul_version           = "v1.9.0"
+  min_consul_version       = "v1.9.0"
   vnet_cidr                = "172.25.16.0/24"
   consul_datacenter        = "hcs-tf-federation-example"
 }
@@ -116,7 +116,7 @@ resource "hcs_cluster" "secondary" {
   managed_application_name = "hcs-tf-federation-secondary"
   email                    = "me@example.com"
   cluster_mode             = "production"
-  consul_version           = "v1.9.0"
+  min_consul_version       = "v1.9.0"
   vnet_cidr                = "172.25.17.0/24"
   consul_datacenter        = "hcs-tf-federation-secondary"
   consul_federation_token  = data.hcs_federation_token.fed.token

--- a/docs/guides/federation.md
+++ b/docs/guides/federation.md
@@ -21,7 +21,7 @@ resource "hcs_cluster" "primary" {
   managed_application_name = "hcs-tf-federation-primary"
   email                    = "me@example.com"
   cluster_mode             = "production"
-  consul_version           = "v1.9.0"
+  min_consul_version       = "v1.9.0"
   vnet_cidr                = "172.25.16.0/24"
   consul_datacenter        = "hcs-tf-federation-example"
 }
@@ -41,7 +41,7 @@ resource "hcs_cluster" "secondary" {
   managed_application_name = "hcs-tf-federation-secondary"
   email                    = "me@example.com"
   cluster_mode             = "production"
-  consul_version           = "v1.9.0"
+  min_consul_version       = "v1.9.0"
   vnet_cidr                = "172.25.17.0/24"
   consul_datacenter        = "hcs-tf-federation-secondary"
   consul_federation_token  = data.hcs_federation_token.test.token

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -22,7 +22,7 @@ resource "hcs_cluster" "example" {
   email                    = var.email
   cluster_mode             = var.cluster_mode
   vnet_cidr                = var.vnet_cidr
-  consul_version           = data.hcs_consul_versions.default.recommended
+  min_consul_version       = data.hcs_consul_versions.default.recommended
   location                 = var.location
   plan_name                = data.hcs_plan_defaults.default.plan_name
 }
@@ -43,10 +43,10 @@ resource "hcs_cluster" "example" {
 - **consul_datacenter** (String) The Consul data center name of the cluster. If not specified, it is defaulted to the value of `managed_application_name`.
 - **consul_external_endpoint** (Boolean) Denotes that the cluster has an external endpoint for the Consul UI. Defaults to `false`.
 - **consul_federation_token** (String) The token used to join a federation of Consul clusters. If the cluster is not part of a federation, this field will be empty.
-- **consul_version** (String) The Consul version of the cluster. If not specified, it is defaulted to the version that is currently recommended by HCS.
 - **id** (String) The ID of this resource.
 - **location** (String) The Azure region that the cluster is deployed to. If not specified, it is defaulted to the region of the Resource Group the Managed Application belongs to.
 - **managed_resource_group_name** (String) The name of the Managed Resource Group in which the cluster resources belong. If not specified, it is defaulted to the value of `managed_application_name` with 'mrg-' prepended.
+- **min_consul_version** (String) The minimum Consul version of the cluster. If not specified, it is defaulted to the version that is currently recommended by HCS.
 - **plan_name** (String) The name of the Azure Marketplace HCS plan for the cluster. If not specified, it will default to the current HCS default plan (see the `hcs_plan_defaults` data source).
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - **vnet_cidr** (String) The VNET CIDR range of the Consul cluster. Defaults to `172.25.16.0/24`.
@@ -65,6 +65,7 @@ resource "hcs_cluster" "example" {
 - **consul_root_token_secret_id** (String, Sensitive) The secret ID of the root ACL token that is generated upon cluster creation. If a new root token is generated using the `hcs_cluster_root_token` resource, this field is no longer valid.
 - **consul_snapshot_interval** (String) The Consul snapshot interval.
 - **consul_snapshot_retention** (String) The retention policy for Consul snapshots.
+- **consul_version** (String) The Consul version of the cluster.
 - **managed_application_id** (String) The ID of the Managed Application.
 - **state** (String) The state of the cluster.
 - **storage_account_name** (String) The name of the Storage Account in which cluster data is persisted.

--- a/examples/federation/main.tf
+++ b/examples/federation/main.tf
@@ -8,7 +8,7 @@ resource "hcs_cluster" "primary" {
   managed_application_name = "hcs-tf-federation-primary"
   email                    = "me@example.com"
   cluster_mode             = "production"
-  consul_version           = "v1.9.0"
+  min_consul_version       = "v1.9.0"
   vnet_cidr                = "172.25.16.0/24"
   consul_datacenter        = "hcs-tf-federation-example"
 }
@@ -28,7 +28,7 @@ resource "hcs_cluster" "secondary" {
   managed_application_name = "hcs-tf-federation-secondary"
   email                    = "me@example.com"
   cluster_mode             = "production"
-  consul_version           = "v1.9.0"
+  min_consul_version       = "v1.9.0"
   vnet_cidr                = "172.25.17.0/24"
   consul_datacenter        = "hcs-tf-federation-secondary"
   consul_federation_token  = data.hcs_federation_token.test.token

--- a/examples/resources/hcs_cluster/resource.tf
+++ b/examples/resources/hcs_cluster/resource.tf
@@ -8,7 +8,7 @@ resource "hcs_cluster" "example" {
   email                    = var.email
   cluster_mode             = var.cluster_mode
   vnet_cidr                = var.vnet_cidr
-  consul_version           = data.hcs_consul_versions.default.recommended
+  min_consul_version       = data.hcs_consul_versions.default.recommended
   location                 = var.location
   plan_name                = data.hcs_plan_defaults.default.plan_name
 }


### PR DESCRIPTION
[HCS-1627](https://hashicorp.atlassian.net/browse/HCS-1627)
Per discussion with @dadgar on the RFC, we would like to use the optional `min_consul_version` property on the `hcs_cluster` resource to drive the initial version of Consul that the cluster is created with. `min_consul_version` can also be used to initiate a Consul version upgrade of the cluster.

We prefer using the `min_` prefix instead of just `consul_version` because an operator initiated upgrade of a cluster's Consul version (ie the version of Consul for the cluster has a CVE) would introduce an unexpected diff to the user if we were to allow an explicit `consul_version` property to be set. Using `min_consul_version` avoids this problem by letting the user specify the minimum Consul version they desire and the current Consul version of the cluster is reflected in a computed property in the Terraform state.