### PR TITLE
HCS-1628: Delay after AMA deletion to avoid ResourcePurchaseCanceling errors

### DIFF
--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -649,7 +649,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 
 	// Sleep to prevent ResourcePurchaseCanceling errors returned from Azure during the scenario when
 	// a cluster resource must be deleted and re-created.
-	time.Sleep(time.Second * 30)
+	time.Sleep(time.Minute)
 
 	return nil
 }


### PR DESCRIPTION
[HCS-1628](https://hashicorp.atlassian.net/browse/HCS-1628)
@xargs-P ran into the Azure `ResourcePurchaseCanceling` error when his cluster was deleted and re-created with the same Managed App name. We have seen these errors in the past with HCS tests and the cause seems to be a propagation delay between Azure responding that a resource was deleted, and the resource _actually_ being deleted.

In order to avoid these types of errors when cluster resources need to be deleted and recreated by Terraform, we sleep after the Managed App is deleted to give Azure time to propagate resource state.