### PR TITLE
Use HCP_MARKETPLACE_PRODUCT_NAME to set product name

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -54,7 +54,7 @@ func New() func() *schema.Provider {
 				"hcs_marketplace_product_name": {
 					Type:        schema.TypeString,
 					Optional:    true,
-					DefaultFunc: schema.EnvDefaultFunc("HCP_PLAN", "hcs-production"),
+					DefaultFunc: schema.EnvDefaultFunc("HCP_MARKETPLACE_PRODUCT_NAME", "hcs-production"),
 					Description: "The HashiCorp Consul Service product name on the Azure marketplace.",
 				},
 				// We must support the same optional fields found in the azurerm provider schema


### PR DESCRIPTION
`HCP_PLAN` is vague and can mean many things in the context of the Azure Marketplace offering. Lets be more descriptive to denote that it is the product name: `HCP_MARKETPLACE_PRODUCT_NAME`