### PR TITLE
Adjust cluster resource timeouts to allow for longer create/update

### DIFF
--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -19,7 +19,13 @@ import (
 	"github.com/hashicorp/terraform-provider-hcs/internal/helper"
 )
 
-var createUpdateDeleteTimeoutDuration = time.Minute * 25
+// createUpdateTimeoutDuration is the amount of time that can elapse
+// before a cluster create or update operation should timeout.
+var createUpdateTimeoutDuration = time.Minute * 40
+
+// deleteTimeoutDuration is the amount of time that can elapse
+// before a cluster delete operation should timeout.
+var deleteTimeoutDuration = time.Minute * 25
 
 // managedAppParamValue is the container struct for passing AMA values on creation/update.
 type managedAppParamValue struct {
@@ -38,9 +44,9 @@ func resourceCluster() *schema.Resource {
 		DeleteContext: resourceClusterDelete,
 		Timeouts: &schema.ResourceTimeout{
 			Default: &defaultClusterTimeoutDuration,
-			Create:  &createUpdateDeleteTimeoutDuration,
-			Update:  &createUpdateDeleteTimeoutDuration,
-			Delete:  &createUpdateDeleteTimeoutDuration,
+			Create:  &createUpdateTimeoutDuration,
+			Update:  &createUpdateTimeoutDuration,
+			Delete:  &deleteTimeoutDuration,
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceClusterImport,


### PR DESCRIPTION
We have seen some E2E tests fail due to context cancellation while waiting for cluster creation. We should increase the client timeout so we can get a proper error back from Azure in the case of a true failure.