### PR TITLE
Update version validation to do full semver parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1 (Unreleased)
+
+IMPROVEMENTS:
+* `hcs_cluster`: `min_consul_version` now can handle semver versions with metadata or a prerelease.
+
 ## 0.1.0 (January 15, 2021)
 
 FEATURES:

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/go-uuid v1.0.2
+	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.0
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -261,13 +261,28 @@ func Test_validateSemVer(t *testing.T) {
 			input:    "1.2.3",
 			expected: nil,
 		},
+		"with prerelease": {
+			input:    "v1.2.3-unreleased",
+			expected: nil,
+		},
 		"invalid semver": {
-			input: "v1.2.3.4.5",
+			input: "v1.2.foo",
 			expected: diag.Diagnostics{
 				diag.Diagnostic{
 					Severity:      diag.Error,
 					Summary:       "must be a valid semver",
-					Detail:        "must be a valid semver",
+					Detail:        "Malformed version: v1.2.foo",
+					AttributePath: nil,
+				},
+			},
+		},
+		"too many segments": {
+			input: "v1.2.3.4.5",
+			expected: diag.Diagnostics{
+				diag.Diagnostic{
+					Severity:      diag.Error,
+					Summary:       "version must have 3 segments",
+					Detail:        "version must have 3 segments",
 					AttributePath: nil,
 				},
 			},


### PR DESCRIPTION
This enables us to handle prerelease versions for nightly testing of consul-enterprise compatibility with HCS