### PR TITLE
Set clusterMode on AMA params when creating an hcs_cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0 (Unreleased)
+
+BUG FIXES:
+* Pass `cluster_mode` as a property when creating the `hcs_cluster` resource.
+
 ## 0.2.0 (March 01, 2021)
 
 IMPROVEMENTS:

--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -392,6 +392,9 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	hcsAMAParams := map[string]managedAppParamValue{
+		"clusterMode": {
+			Value: strings.ToUpper(d.Get("cluster_mode").(string)),
+		},
 		"clusterName": {
 			Value: clusterName,
 		},


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-hcs/issues/63

```
~/go/src/github.com/hashicorp/terraform-provider-hcs/examples/quick_start munda/pass-cluster-mode* 25s
❯ tf apply

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_resource_group.example will be created
  + resource "azurerm_resource_group" "example" {
      + id       = (known after apply)
      + location = "westus2"
      + name     = "munda"
    }

  # hcs_cluster.example will be created
  + resource "hcs_cluster" "example" {
      + blob_container_name            = (known after apply)
      + cluster_mode                   = "development"
      + cluster_name                   = (known after apply)
      + consul_automatic_upgrades      = (known after apply)
      + consul_ca_file                 = (known after apply)
      + consul_cluster_id              = (known after apply)
      + consul_config_file             = (known after apply)
      + consul_connect                 = (known after apply)
      + consul_datacenter              = (known after apply)
      + consul_external_endpoint       = false
      + consul_external_endpoint_url   = (known after apply)
      + consul_private_endpoint_url    = (known after apply)
      + consul_root_token_accessor_id  = (known after apply)
      + consul_root_token_secret_id    = (sensitive value)
      + consul_snapshot_interval       = (known after apply)
      + consul_snapshot_retention      = (known after apply)
      + consul_version                 = (known after apply)
      + email                          = "amunda@hashicorp.com"
      + id                             = (known after apply)
      + location                       = (known after apply)
      + managed_application_id         = (known after apply)
      + managed_application_name       = "munda"
      + managed_resource_group_name    = (known after apply)
      + plan_name                      = (known after apply)
      + resource_group_name            = "munda"
      + state                          = (known after apply)
      + storage_account_name           = (known after apply)
      + storage_account_resource_group = (known after apply)
      + vnet_cidr                      = "172.25.16.0/24"
      + vnet_id                        = (known after apply)
      + vnet_name                      = (known after apply)
      + vnet_resource_group_name       = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

azurerm_resource_group.example: Creating...
azurerm_resource_group.example: Creation complete after 6s [id=/subscriptions/XXX/resourceGroups/munda]
hcs_cluster.example: Creating...
...
hcs_cluster.example: Still creating... [9m10s elapsed]
hcs_cluster.example: Creation complete after 9m17s [id=/subscriptions/XXX/resourceGroups/munda/providers/Microsoft.Solutions/applications/munda]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

~/go/src/github.com/hashicorp/terraform-provider-hcs/examples/quick_start munda/pass-cluster-mode* 10m 9s
❯ tf plan
azurerm_resource_group.example: Refreshing state... [id=/subscriptions/XXX/resourceGroups/munda]
hcs_cluster.example: Refreshing state... [id=/subscriptions/XXX/resourceGroups/munda/providers/Microsoft.Solutions/applications/munda]

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```