### PR TITLE
Fix terraform updates for min_consul_version

### DIFF
--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -111,14 +111,17 @@ func resourceCluster() *schema.Resource {
 				Optional:         true,
 				ValidateDiagFunc: validateSemVer,
 				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-					// Suppress diff is normalized versions match OR min_consul_version is removed from the resource
-					// since min_consul_version is required in order to upgrade the cluster to a new Consul version.
+					// Suppress diff for non specified value
+					if new == "" || old == "" {
+						return true
+					}
+
 					actualConsulVersion := version.Must(version.NewVersion(old))
 					currentTFVersion := version.Must(version.NewVersion(new))
 					log.Printf("[DEBUG] Actual Consul Version %v", old)
 					log.Printf("[DEBUG] Current TF Version %v", new)
-
-					return currentTFVersion.LessThanOrEqual(actualConsulVersion) || new == ""
+					// suppres diff if the specified min_consul_version is <= to the actual consul version
+					return currentTFVersion.LessThanOrEqual(actualConsulVersion)
 				},
 			},
 			"consul_datacenter": {

--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/managedapplications"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -112,7 +113,12 @@ func resourceCluster() *schema.Resource {
 				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 					// Suppress diff is normalized versions match OR min_consul_version is removed from the resource
 					// since min_consul_version is required in order to upgrade the cluster to a new Consul version.
-					return consul.NormalizeVersion(old) == consul.NormalizeVersion(new) || new == ""
+					actualConsulVersion := version.Must(version.NewVersion(old))
+					currentTFVersion := version.Must(version.NewVersion(new))
+					log.Printf("[DEBUG] Actual Consul Version %v", old)
+					log.Printf("[DEBUG] Current TF Version %v", new)
+
+					return currentTFVersion.LessThanOrEqual(actualConsulVersion) || new == ""
 				},
 			},
 			"consul_datacenter": {
@@ -938,6 +944,10 @@ func setClusterData(d *schema.ResourceData, managedApp managedapplications.Appli
 
 	err = d.Set("consul_version", cluster.Properties.ConsulCurrentVersion)
 	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("min_consul_version", cluster.Properties.ConsulCurrentVersion); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
If an update fails subsequent terraform runs consider the state correct. This is because the current cluster version is not validated against the min_consul_version.

### :hammer_and_wrench: Description

Added  min_consul_version to read and set it to the consul_version. We can suppress the diff when the cluster version is greater than or equal to the what is set in the terraform by the user.

### :building_construction: Acceptance tests

- ~~[ ] Are there any feature flags that are required to use this functionality?~~
- ~~[ ] Have you added an acceptance test for the functionality being added?~~
- [X] Have you run the acceptance tests on this branch?

