### PR TITLE
HCS-2849: Do not suppress min_consul_version on create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.1 (Unreleased)
+
+BUG FIXES:
+* Do not suppress `min_consul_version` on creation.
+
 ## 0.5.0 (September 22, 2021)
 
 IMPROVEMENTS:

--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -112,8 +112,11 @@ func resourceCluster() *schema.Resource {
 				ValidateDiagFunc: validateSemVer,
 				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 					// Suppress diff for non specified value
-					if new == "" || old == "" {
+					if new == "" {
 						return true
+					}
+					if old == "" {
+						return false
 					}
 
 					actualConsulVersion := version.Must(version.NewVersion(old))


### PR DESCRIPTION
This code fixes an issue where `min_consul_version` was not respected on create. The issue was caused by suppressing the diff if there was no previous min_consul_version, which results in the value not being set.